### PR TITLE
Update water drop and wet clump shader hashes

### DIFF
--- a/Mods/BufferValues/Tracking.ini
+++ b/Mods/BufferValues/Tracking.ini
@@ -112,7 +112,7 @@ filter_index = 200
 hash = cb888b02
 filter_index = 111
 [ShaderOverride Wetness Drops PS]
-hash = 3903fd3503164bed
+hash = ec1f2fef5db01aad
 if ps-t0 == 111
 	$wetCheck = 1
 endif
@@ -120,7 +120,7 @@ endif
 hash = 7c273609
 filter_index = 112
 [ShaderOverride Wetness Clumps PS]
-hash = 47d8e182f906cd12
+hash = b9707c413ce793db
 if ps-t0 == 112
 	$wetCheck = 1
 endif


### PR DESCRIPTION
Closes #4. Per my comment in that issue I was able to hunt for the new shader hashes and they have been working for me for the past 3 weeks without issue.